### PR TITLE
Remove description character limit in OpenGraph helper

### DIFF
--- a/lib/plugins/helper/open_graph.js
+++ b/lib/plugins/helper/open_graph.js
@@ -42,7 +42,7 @@ function openGraphHelper(options) {
   if (!Array.isArray(images)) images = [images];
 
   if (description) {
-    description = stripHTML(description).substring(0, 200)
+    description = stripHTML(description)
       .replace(/^\s+|\s+$/g, '') // Remove prefixing/trailing spaces
       .replace(/</g, '&lt;')
       .replace(/>/g, '&gt;')


### PR DESCRIPTION
The character limit is unnecessary since a long description won’t break
either Facebook, nor Twitter, and search engines will filter out the
most relevant sections anyway. The hardcoded character limit is
annoying. It should be left to the writer to decide.
